### PR TITLE
ref(*): rename client package to deis

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
@@ -21,7 +21,7 @@ var ErrNoLogs = errors.New(
 3) Making sure that the container logs were mounted properly into the fluentd pod: kubectl exec <fluentd pod> --namespace=deis ls /var/log/containers`)
 
 // List lists apps on a Deis controller.
-func List(c *client.Client, results int) ([]api.App, int, error) {
+func List(c *deis.Client, results int) ([]api.App, int, error) {
 	body, count, err := c.LimitedRequest("/v2/apps/", results)
 
 	if err != nil {
@@ -43,7 +43,7 @@ func List(c *client.Client, results int) ([]api.App, int, error) {
 }
 
 // New creates a new app.
-func New(c *client.Client, id string) (api.App, error) {
+func New(c *deis.Client, id string) (api.App, error) {
 	body := []byte{}
 
 	var err error
@@ -74,7 +74,7 @@ func New(c *client.Client, id string) (api.App, error) {
 }
 
 // Get app details from a Deis controller.
-func Get(c *client.Client, appID string) (api.App, error) {
+func Get(c *deis.Client, appID string) (api.App, error) {
 	u := fmt.Sprintf("/v2/apps/%s/", appID)
 
 	body, err := c.BasicRequest("GET", u, nil)
@@ -96,7 +96,7 @@ func Get(c *client.Client, appID string) (api.App, error) {
 }
 
 // Logs retrieves logs from an app.
-func Logs(c *client.Client, appID string, lines int) (string, error) {
+func Logs(c *deis.Client, appID string, lines int) (string, error) {
 	u := fmt.Sprintf("/v2/apps/%s/logs", appID)
 
 	if lines > 0 {
@@ -115,7 +115,7 @@ func Logs(c *client.Client, appID string, lines int) (string, error) {
 }
 
 // Run one time command in an app.
-func Run(c *client.Client, appID string, command string) (api.AppRunResponse, error) {
+func Run(c *deis.Client, appID string, command string) (api.AppRunResponse, error) {
 	req := api.AppRunRequest{Command: command}
 	body, err := json.Marshal(req)
 
@@ -141,7 +141,7 @@ func Run(c *client.Client, appID string, command string) (api.AppRunResponse, er
 }
 
 // Delete an app.
-func Delete(c *client.Client, appID string) error {
+func Delete(c *deis.Client, appID string) error {
 	u := fmt.Sprintf("/v2/apps/%s/", appID)
 
 	_, err := c.BasicRequest("DELETE", u, nil)
@@ -149,7 +149,7 @@ func Delete(c *client.Client, appID string) error {
 }
 
 // Transfer an app to another user.
-func Transfer(c *client.Client, appID string, username string) error {
+func Transfer(c *deis.Client, appID string, username string) error {
 	u := fmt.Sprintf("/v2/apps/%s/", appID)
 
 	req := api.AppUpdateRequest{Owner: username}

--- a/apps/apps_test.go
+++ b/apps/apps_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
@@ -50,7 +50,7 @@ type fakeHTTPServer struct {
 }
 
 func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	res.Header().Add("DEIS_API_VERSION", client.APIVersion)
+	res.Header().Add("DEIS_API_VERSION", deis.APIVersion)
 
 	if req.URL.Path == "/v2/apps/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
@@ -173,13 +173,13 @@ func TestAppsCreate(t *testing.T) {
 		UUID:    "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
 	}
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, id := range []string{"example-go", ""} {
-		actual, err := New(client, id)
+		actual, err := New(deis, id)
 
 		if err != nil {
 			t.Fatal(err)
@@ -209,12 +209,12 @@ func TestAppsGet(t *testing.T) {
 		UUID:    "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
 	}
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := Get(client, "example-go")
+	actual, err := Get(deis, "example-go")
 
 	if err != nil {
 		t.Fatal(err)
@@ -232,12 +232,12 @@ func TestAppsDestroy(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = Delete(client, "example-go"); err != nil {
+	if err = Delete(deis, "example-go"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -254,12 +254,12 @@ func TestAppsRun(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := Run(client, "example-go", "echo hi")
+	actual, err := Run(deis, "example-go", "echo hi")
 
 	if err != nil {
 		t.Fatal(err)
@@ -290,12 +290,12 @@ func TestAppsList(t *testing.T) {
 		},
 	}
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, _, err := List(client, 100)
+	actual, _, err := List(deis, 100)
 
 	if err != nil {
 		t.Fatal(err)
@@ -329,13 +329,13 @@ func TestAppsLogs(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, test := range tests {
-		actual, err := Logs(client, "example-go", test.Input)
+		actual, err := Logs(deis, "example-go", test.Input)
 
 		if err != nil {
 			t.Error(err)
@@ -354,12 +354,12 @@ func TestAppsTransfer(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = Transfer(client, "example-go", "test"); err != nil {
+	if err = Transfer(deis, "example-go", "test"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -3,12 +3,12 @@ package auth
 import (
 	"encoding/json"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
 // Register a new user with the controller.
-func Register(c *client.Client, username, password, email string) error {
+func Register(c *deis.Client, username, password, email string) error {
 	user := api.AuthRegisterRequest{Username: username, Password: password, Email: email}
 	body, err := json.Marshal(user)
 
@@ -21,7 +21,7 @@ func Register(c *client.Client, username, password, email string) error {
 }
 
 // Login to the controller and get a token
-func Login(c *client.Client, username, password string) (string, error) {
+func Login(c *deis.Client, username, password string) (string, error) {
 	user := api.AuthLoginRequest{Username: username, Password: password}
 	reqBody, err := json.Marshal(user)
 
@@ -44,7 +44,7 @@ func Login(c *client.Client, username, password string) (string, error) {
 }
 
 // Delete deletes a user.
-func Delete(c *client.Client, username string) error {
+func Delete(c *deis.Client, username string) error {
 	var body []byte
 	var err error
 
@@ -62,7 +62,7 @@ func Delete(c *client.Client, username string) error {
 }
 
 // Regenerate user's auth tokens.
-func Regenerate(c *client.Client, username string, all bool) (string, error) {
+func Regenerate(c *deis.Client, username string, all bool) (string, error) {
 	var reqBody []byte
 	var err error
 
@@ -95,7 +95,7 @@ func Regenerate(c *client.Client, username string, all bool) (string, error) {
 }
 
 // Passwd changes a user's password.
-func Passwd(c *client.Client, username, password, newPassword string) error {
+func Passwd(c *deis.Client, username, password, newPassword string) error {
 	req := api.AuthPasswdRequest{Password: password, NewPassword: newPassword}
 
 	if username != "" {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 )
 
 const registerExpected string = `{"username":"test","password":"opensesame","email":"test@example.com"}`
@@ -28,7 +28,7 @@ type fakeHTTPServer struct {
 }
 
 func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	res.Header().Add("DEIS_API_VERSION", client.APIVersion)
+	res.Header().Add("DEIS_API_VERSION", deis.APIVersion)
 
 	if req.URL.Path == "/v2/auth/register/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
@@ -166,12 +166,12 @@ func TestRegister(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = Register(client, "test", "opensesame", "test@example.com"); err != nil {
+	if err = Register(deis, "test", "opensesame", "test@example.com"); err != nil {
 		t.Error(err)
 	}
 }
@@ -183,12 +183,12 @@ func TestLogin(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := Login(client, "test", "opensesame")
+	actual, err := Login(deis, "test", "opensesame")
 
 	if err != nil {
 		t.Error(err)
@@ -208,12 +208,12 @@ func TestPasswd(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := Passwd(client, "test", "old", "new"); err != nil {
+	if err := Passwd(deis, "test", "old", "new"); err != nil {
 		t.Error(err)
 	}
 }
@@ -225,16 +225,16 @@ func TestDelete(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := Delete(client, "foo"); err != nil {
+	if err := Delete(deis, "foo"); err != nil {
 		t.Error(err)
 	}
 
-	if err := Delete(client, ""); err != nil {
+	if err := Delete(deis, ""); err != nil {
 		t.Error(err)
 	}
 }
@@ -246,12 +246,12 @@ func TestDeleteUserApp(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = Delete(client, "admin")
+	err = Delete(deis, "admin")
 	// should be a 409 Conflict
 
 	expected := fmt.Errorf("\n%s %s\n\n", "409", "Conflict")
@@ -267,12 +267,12 @@ func TestRegenerate(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	token, err := Regenerate(client, "", true)
+	token, err := Regenerate(deis, "", true)
 
 	if err != nil {
 		t.Error(err)
@@ -282,7 +282,7 @@ func TestRegenerate(t *testing.T) {
 		t.Errorf("Expected token be empty, Got %s", token)
 	}
 
-	token, err = Regenerate(client, "test", false)
+	token, err = Regenerate(deis, "test", false)
 
 	if err != nil {
 		t.Error(err)
@@ -293,7 +293,7 @@ func TestRegenerate(t *testing.T) {
 		t.Errorf("Expected %s, Got %s", expected, token)
 	}
 
-	token, err = Regenerate(client, "", false)
+	token, err = Regenerate(deis, "", false)
 
 	if err != nil {
 		t.Error(err)

--- a/builds/builds.go
+++ b/builds/builds.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
 // List lists an app's builds.
-func List(c *client.Client, appID string, results int) ([]api.Build, int, error) {
+func List(c *deis.Client, appID string, results int) ([]api.Build, int, error) {
 	u := fmt.Sprintf("/v2/apps/%s/builds/", appID)
 	body, count, err := c.LimitedRequest(u, results)
 
@@ -26,7 +26,7 @@ func List(c *client.Client, appID string, results int) ([]api.Build, int, error)
 }
 
 // New creates a build for an app.
-func New(c *client.Client, appID string, image string,
+func New(c *deis.Client, appID string, image string,
 	procfile map[string]string) (api.Build, error) {
 
 	u := fmt.Sprintf("/v2/apps/%s/builds/", appID)

--- a/builds/builds_test.go
+++ b/builds/builds_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
@@ -54,7 +54,7 @@ const buildExpected string = `{"image":"deis/example-go","procfile":{"web":"exam
 type fakeHTTPServer struct{}
 
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	res.Header().Add("DEIS_API_VERSION", client.APIVersion)
+	res.Header().Add("DEIS_API_VERSION", deis.APIVersion)
 
 	if req.URL.Path == "/v2/apps/example-go/builds/" && req.Method == "GET" {
 		res.Write([]byte(buildsFixture))
@@ -110,12 +110,12 @@ func TestBuildsList(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, _, err := List(client, "example-go", 100)
+	actual, _, err := List(deis, "example-go", 100)
 
 	if err != nil {
 		t.Fatal(err)
@@ -145,7 +145,7 @@ func TestBuildCreate(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestBuildCreate(t *testing.T) {
 		"web": "example-go",
 	}
 
-	actual, err := New(client, "example-go", "deis/example-go", procfile)
+	actual, err := New(deis, "example-go", "deis/example-go", procfile)
 
 	if err != nil {
 		t.Fatal(err)

--- a/certs/certs.go
+++ b/certs/certs.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
 // List certs registered with the controller.
-func List(c *client.Client, results int) ([]api.Cert, int, error) {
+func List(c *deis.Client, results int) ([]api.Cert, int, error) {
 	body, count, err := c.LimitedRequest("/v2/certs/", results)
 
 	if err != nil {
@@ -25,7 +25,7 @@ func List(c *client.Client, results int) ([]api.Cert, int, error) {
 }
 
 // New creates a cert.
-func New(c *client.Client, cert string, key string, name string) (api.Cert, error) {
+func New(c *deis.Client, cert string, key string, name string) (api.Cert, error) {
 	req := api.CertCreateRequest{Certificate: cert, Key: key, Name: name}
 	reqBody, err := json.Marshal(req)
 	if err != nil {
@@ -46,7 +46,7 @@ func New(c *client.Client, cert string, key string, name string) (api.Cert, erro
 }
 
 // Get information for a certificate
-func Get(c *client.Client, name string) (api.Cert, error) {
+func Get(c *deis.Client, name string) (api.Cert, error) {
 	url := fmt.Sprintf("/v2/certs/%s", name)
 	body, err := c.BasicRequest("GET", url, nil)
 	if err != nil {
@@ -62,14 +62,14 @@ func Get(c *client.Client, name string) (api.Cert, error) {
 }
 
 // Delete removes a cert.
-func Delete(c *client.Client, name string) error {
+func Delete(c *deis.Client, name string) error {
 	url := fmt.Sprintf("/v2/certs/%s", name)
 	_, err := c.BasicRequest("DELETE", url, nil)
 	return err
 }
 
 // Attach a certificate to a domain
-func Attach(c *client.Client, name string, domain string) error {
+func Attach(c *deis.Client, name string, domain string) error {
 	req := api.CertAttachRequest{Domain: domain}
 	reqBody, err := json.Marshal(req)
 	if err != nil {
@@ -82,7 +82,7 @@ func Attach(c *client.Client, name string, domain string) error {
 }
 
 // Detach a certificate from a domain
-func Detach(c *client.Client, name string, domain string) error {
+func Detach(c *deis.Client, name string, domain string) error {
 	url := fmt.Sprintf("/v2/certs/%s/domain/%s", name, domain)
 	_, err := c.BasicRequest("DELETE", url, nil)
 	return err

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 	"github.com/deis/pkg/time"
 )
@@ -45,7 +45,7 @@ const certExpected string = `{"certificate":"test","key":"foo","name":"test-exam
 type fakeHTTPServer struct{}
 
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	res.Header().Add("DEIS_API_VERSION", client.APIVersion)
+	res.Header().Add("DEIS_API_VERSION", deis.APIVersion)
 
 	if req.URL.Path == "/v2/certs/" && req.Method == "GET" {
 		res.Write([]byte(certsFixture))
@@ -122,12 +122,12 @@ func TestCertsList(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, _, err := List(client, 100)
+	actual, _, err := List(deis, 100)
 
 	if err != nil {
 		t.Fatal(err)
@@ -161,12 +161,12 @@ func TestCert(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := New(client, "test", "foo", "test-example-com")
+	actual, err := New(deis, "test", "foo", "test-example-com")
 
 	if err != nil {
 		t.Fatal(err)
@@ -200,12 +200,12 @@ func TestCertInfo(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := Get(client, "test-example-com")
+	actual, err := Get(deis, "test-example-com")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,16 +222,16 @@ func TestCertDeletion(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = Delete(client, "test-example-com"); err != nil {
+	if err = Delete(deis, "test-example-com"); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := Delete(client, "non-existent-cert"); err == nil {
+	if err := Delete(deis, "non-existent-cert"); err == nil {
 		t.Fatal("An Error should have resulted from the attempt to delete a non-existent-cert")
 	}
 }
@@ -243,21 +243,21 @@ func TestCertAttach(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = Attach(client, "test-example-com", "foo.com"); err != nil {
+	if err = Attach(deis, "test-example-com", "foo.com"); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := Attach(client, "non-existent-cert", "foo.com"); err == nil {
+	if err := Attach(deis, "non-existent-cert", "foo.com"); err == nil {
 		t.Fatal("An Error should have resulted from the attempt to attach a non-existent cert to a valid domain")
 	}
 
 	// TODO: #475
-	// if err := Attach(&client, "test-example-com", "non-existent.domain.com"); err == nil {
+	// if err := Attach(&deis, "test-example-com", "non-existent.domain.com"); err == nil {
 	// 	t.Fatal("An Error should have resulted from the attempt to attach a valid cert to a non-existent domain")
 	// }
 }
@@ -269,20 +269,20 @@ func TestCertDetach(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = Detach(client, "test-example-com", "foo.com"); err != nil {
+	if err = Detach(deis, "test-example-com", "foo.com"); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := Detach(client, "non-existent-cert", "foo.com"); err == nil {
+	if err := Detach(deis, "non-existent-cert", "foo.com"); err == nil {
 		t.Fatal("An Error should have resulted from the attempt to detach a non-existent cert from a valid domain")
 	}
 
-	if err := Detach(client, "test-example-com", "non-existent.domain.com"); err == nil {
+	if err := Detach(deis, "test-example-com", "non-existent.domain.com"); err == nil {
 		t.Fatal("An Error should have resulted from the attempt to detach a valid cert from a non-existent domain")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
 // List lists an app's config.
-func List(c *client.Client, app string) (api.Config, error) {
+func List(c *deis.Client, app string) (api.Config, error) {
 	u := fmt.Sprintf("/v2/apps/%s/config/", app)
 
 	body, err := c.BasicRequest("GET", u, nil)
@@ -27,7 +27,7 @@ func List(c *client.Client, app string) (api.Config, error) {
 }
 
 // Set sets an app's config variables.
-func Set(c *client.Client, app string, config api.Config) (api.Config, error) {
+func Set(c *deis.Client, app string, config api.Config) (api.Config, error) {
 	body, err := json.Marshal(config)
 
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
@@ -59,7 +59,7 @@ const configUnsetExpected string = `{"values":{"FOO":null,"TEST":null},"memory":
 type fakeHTTPServer struct{}
 
 func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	res.Header().Add("DEIS_API_VERSION", client.APIVersion)
+	res.Header().Add("DEIS_API_VERSION", deis.APIVersion)
 
 	if req.URL.Path == "/v2/apps/example-go/config/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
@@ -120,7 +120,7 @@ func TestConfigSet(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestConfigSet(t *testing.T) {
 		},
 	}
 
-	actual, err := Set(client, "example-go", configVars)
+	actual, err := Set(deis, "example-go", configVars)
 
 	if err != nil {
 		t.Error(err)
@@ -186,7 +186,7 @@ func TestConfigUnset(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestConfigUnset(t *testing.T) {
 		},
 	}
 
-	actual, err := Set(client, "unset-test", configVars)
+	actual, err := Set(deis, "unset-test", configVars)
 
 	if err != nil {
 		t.Error(err)
@@ -241,7 +241,7 @@ func TestConfigList(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +270,7 @@ func TestConfigList(t *testing.T) {
 		UUID:    "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
 	}
 
-	actual, err := List(client, "example-go")
+	actual, err := List(deis, "example-go")
 
 	if err != nil {
 		t.Error(err)

--- a/deis.go
+++ b/deis.go
@@ -1,4 +1,4 @@
-package client
+package deis
 
 import (
 	"errors"
@@ -9,9 +9,9 @@ import (
 	"github.com/goware/urlx"
 )
 
-// Client oversees the interaction between the client and controller
+// Client oversees the interaction between the deis and controller
 type Client struct {
-	// HTTP client used to communicate with the API.
+	// HTTP deis used to communicate with the API.
 	HTTPClient *http.Client
 
 	// VerifySSL determines whether or not to verify SSL connections.
@@ -40,8 +40,8 @@ type Client struct {
 const APIVersion = "2.0"
 
 var (
-	// ErrAPIMismatch occurs when the sdk is using a different api version than the client.
-	ErrAPIMismatch = errors.New("API Version Mismatch between server and client")
+	// ErrAPIMismatch occurs when the sdk is using a different api version than the deis.
+	ErrAPIMismatch = errors.New("API Version Mismatch between server and deis")
 
 	// DefaultResponseLimit is the default number of responses to return on requests that can
 	// be limited.
@@ -51,7 +51,7 @@ var (
 	DefaultUserAgent = fmt.Sprintf("Deis Go SDK V%s", APIVersion)
 )
 
-// New creates a new client to communicate with the api.
+// New creates a new deis to communicate with the api.
 func New(verifySSL bool, controllerURL string, token string, username string) (*Client, error) {
 	// urlx, unlike the native url library, uses sane defaults when URL parsing,
 	// preventing issues like missing schemes.

--- a/domains/domains.go
+++ b/domains/domains.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
 // List domains registered with an app.
-func List(c *client.Client, appID string, results int) ([]api.Domain, int, error) {
+func List(c *deis.Client, appID string, results int) ([]api.Domain, int, error) {
 	u := fmt.Sprintf("/v2/apps/%s/domains/", appID)
 	body, count, err := c.LimitedRequest(u, results)
 
@@ -26,7 +26,7 @@ func List(c *client.Client, appID string, results int) ([]api.Domain, int, error
 }
 
 // New adds a domain to an app.
-func New(c *client.Client, appID string, domain string) (api.Domain, error) {
+func New(c *deis.Client, appID string, domain string) (api.Domain, error) {
 	u := fmt.Sprintf("/v2/apps/%s/domains/", appID)
 
 	req := api.DomainCreateRequest{Domain: domain}
@@ -52,7 +52,7 @@ func New(c *client.Client, appID string, domain string) (api.Domain, error) {
 }
 
 // Delete removes a domain from an app.
-func Delete(c *client.Client, appID string, domain string) error {
+func Delete(c *deis.Client, appID string, domain string) error {
 	u := fmt.Sprintf("/v2/apps/%s/domains/%s", appID, domain)
 	_, err := c.BasicRequest("DELETE", u, nil)
 	return err

--- a/domains/domains_test.go
+++ b/domains/domains_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
@@ -42,7 +42,7 @@ const domainCreateExpected string = `{"domain":"example.example.com"}`
 type fakeHTTPServer struct{}
 
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	res.Header().Add("DEIS_API_VERSION", client.APIVersion)
+	res.Header().Add("DEIS_API_VERSION", deis.APIVersion)
 
 	if req.URL.Path == "/v2/apps/example-go/domains/" && req.Method == "GET" {
 		res.Write([]byte(domainsFixture))
@@ -98,12 +98,12 @@ func TestDomainsList(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, _, err := List(client, "example-go", 100)
+	actual, _, err := List(deis, "example-go", 100)
 
 	if err != nil {
 		t.Fatal(err)
@@ -129,12 +129,12 @@ func TestDomainsAdd(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := New(client, "example-go", "example.example.com")
+	actual, err := New(deis, "example-go", "example.example.com")
 
 	if err != nil {
 		t.Fatal(err)
@@ -152,12 +152,12 @@ func TestDomainsRemove(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = Delete(client, "example-go", "test.com"); err != nil {
+	if err = Delete(deis, "example-go", "test.com"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/http.go
+++ b/http.go
@@ -1,4 +1,4 @@
-package client
+package deis
 
 import (
 	"bytes"
@@ -158,7 +158,7 @@ func checkForErrors(res *http.Response, body string) error {
 func (c *Client) CheckConnection() error {
 	errorMessage := `%s does not appear to be a valid Deis controller.
 Make sure that the Controller URI is correct, the server is running and
-your client version is correct.`
+your deis version is correct.`
 
 	// Make a request to /v2/ and expect a 401 respone
 	req, err := http.NewRequest("GET", c.ControllerURL.String()+"/v2/", bytes.NewBuffer(nil))

--- a/http_test.go
+++ b/http_test.go
@@ -1,4 +1,4 @@
-package client
+package deis
 
 import (
 	"fmt"
@@ -100,13 +100,13 @@ func TestCheckConnection(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := New(false, server.URL, "", "")
+	deis, err := New(false, server.URL, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.UserAgent = "test"
+	deis.UserAgent = "test"
 
-	if err = client.CheckConnection(); err != nil {
+	if err = deis.CheckConnection(); err != nil {
 		t.Error(err)
 	}
 }
@@ -118,18 +118,18 @@ func TestAPIMistmatch(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := New(false, server.URL, "", "")
+	deis, err := New(false, server.URL, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.UserAgent = "test"
+	deis.UserAgent = "test"
 
-	if err = client.CheckConnection(); err != ErrAPIMismatch {
+	if err = deis.CheckConnection(); err != ErrAPIMismatch {
 		t.Error("Expected ErrAPIMismatch error")
 	}
 
-	if client.ControllerAPIVersion != handler.Version {
-		t.Errorf("Expected %s, Got %s", handler.Version, client.ControllerAPIVersion)
+	if deis.ControllerAPIVersion != handler.Version {
+		t.Errorf("Expected %s, Got %s", handler.Version, deis.ControllerAPIVersion)
 	}
 }
 
@@ -140,13 +140,13 @@ func TestBasicRequest(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := New(false, server.URL, "abc", "")
+	deis, err := New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.UserAgent = "test"
+	deis.UserAgent = "test"
 
-	body, err := client.BasicRequest("POST", "/basic/", []byte("test"))
+	body, err := deis.BasicRequest("POST", "/basic/", []byte("test"))
 
 	if err != nil {
 		t.Fatal(err)
@@ -157,13 +157,13 @@ func TestBasicRequest(t *testing.T) {
 		t.Errorf("Expected %s, Got %s", expected, body)
 	}
 
-	if client.ControllerAPIVersion != handler.Version {
-		t.Errorf("Expected %s, Got %s", handler.Version, client.ControllerAPIVersion)
+	if deis.ControllerAPIVersion != handler.Version {
+		t.Errorf("Expected %s, Got %s", handler.Version, deis.ControllerAPIVersion)
 	}
 
 	// Make sure the request doesn't modify the URL
-	if client.ControllerURL.String() != server.URL {
-		t.Errorf("Expected %s, Got %s", server.URL, client.ControllerURL.String())
+	if deis.ControllerURL.String() != server.URL {
+		t.Errorf("Expected %s, Got %s", server.URL, deis.ControllerURL.String())
 	}
 }
 
@@ -263,16 +263,16 @@ func TestLimitedRequest(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := New(false, server.URL, "abc", "")
+	deis, err := New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.UserAgent = "test"
+	deis.UserAgent = "test"
 
 	expected := `[{"test":"foo"},{"test":"bar"}]`
 	expectedC := 4
 
-	actual, count, err := client.LimitedRequest("/limited/", 2)
+	actual, count, err := deis.LimitedRequest("/limited/", 2)
 
 	if err != nil {
 		t.Fatal(err)
@@ -286,12 +286,12 @@ func TestLimitedRequest(t *testing.T) {
 		t.Errorf("Expected %s, Got %s", expected, actual)
 	}
 
-	if client.ControllerAPIVersion != handler.Version {
-		t.Errorf("Expected %s, Got %s", handler.Version, client.ControllerAPIVersion)
+	if deis.ControllerAPIVersion != handler.Version {
+		t.Errorf("Expected %s, Got %s", handler.Version, deis.ControllerAPIVersion)
 	}
 
 	// Make sure the request doesn't modify the URL
-	if client.ControllerURL.String() != server.URL {
-		t.Errorf("Expected %s, Got %s", server.URL, client.ControllerURL.String())
+	if deis.ControllerURL.String() != server.URL {
+		t.Errorf("Expected %s, Got %s", server.URL, deis.ControllerURL.String())
 	}
 }

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
 // List keys on a controller.
-func List(c *client.Client, results int) ([]api.Key, int, error) {
+func List(c *deis.Client, results int) ([]api.Key, int, error) {
 	body, count, err := c.LimitedRequest("/v2/keys/", results)
 
 	if err != nil {
@@ -25,7 +25,7 @@ func List(c *client.Client, results int) ([]api.Key, int, error) {
 }
 
 // New creates a new key.
-func New(c *client.Client, id string, pubKey string) (api.Key, error) {
+func New(c *deis.Client, id string, pubKey string) (api.Key, error) {
 	req := api.KeyCreateRequest{ID: id, Public: pubKey}
 	body, err := json.Marshal(req)
 
@@ -44,7 +44,7 @@ func New(c *client.Client, id string, pubKey string) (api.Key, error) {
 }
 
 // Delete a key.
-func Delete(c *client.Client, keyID string) error {
+func Delete(c *deis.Client, keyID string) error {
 	u := fmt.Sprintf("/v2/keys/%s", keyID)
 
 	_, err := c.BasicRequest("DELETE", u, nil)

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
@@ -44,7 +44,7 @@ const keyCreateExpected string = `{"id":"test@example.com","public":"ssh-rsa abc
 type fakeHTTPServer struct{}
 
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	res.Header().Add("DEIS_API_VERSION", client.APIVersion)
+	res.Header().Add("DEIS_API_VERSION", deis.APIVersion)
 
 	if req.URL.Path == "/v2/keys/" && req.Method == "GET" {
 		res.Write([]byte(keysListFixture))
@@ -101,12 +101,12 @@ func TestKeysList(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, _, err := List(client, 100)
+	actual, _, err := List(deis, 100)
 
 	if err != nil {
 		t.Fatal(err)
@@ -133,12 +133,12 @@ func TestKeyCreate(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := New(client, "test@example.com", "ssh-rsa abc test@example.com")
+	actual, err := New(deis, "test@example.com", "ssh-rsa abc test@example.com")
 
 	if err != nil {
 		t.Fatal(err)
@@ -156,12 +156,12 @@ func TestKeysDestroy(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = Delete(client, "test@example.com"); err != nil {
+	if err = Delete(deis, "test@example.com"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/perms/perms.go
+++ b/perms/perms.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
 // List users that can access an app.
-func List(c *client.Client, appID string) ([]string, error) {
+func List(c *deis.Client, appID string) ([]string, error) {
 	body, err := c.BasicRequest("GET", fmt.Sprintf("/v2/apps/%s/perms/", appID), nil)
 
 	if err != nil {
@@ -25,7 +25,7 @@ func List(c *client.Client, appID string) ([]string, error) {
 }
 
 // ListAdmins lists administrators.
-func ListAdmins(c *client.Client, results int) ([]string, int, error) {
+func ListAdmins(c *deis.Client, results int) ([]string, int, error) {
 	body, count, err := c.LimitedRequest("/v2/admin/perms/", results)
 
 	if err != nil {
@@ -47,16 +47,16 @@ func ListAdmins(c *client.Client, results int) ([]string, int, error) {
 }
 
 // New adds a user to an app.
-func New(c *client.Client, appID string, username string) error {
+func New(c *deis.Client, appID string, username string) error {
 	return doNew(c, fmt.Sprintf("/v2/apps/%s/perms/", appID), username)
 }
 
 // NewAdmin makes a user an administrator.
-func NewAdmin(c *client.Client, username string) error {
+func NewAdmin(c *deis.Client, username string) error {
 	return doNew(c, "/v2/admin/perms/", username)
 }
 
-func doNew(c *client.Client, u string, username string) error {
+func doNew(c *deis.Client, u string, username string) error {
 	req := api.PermsRequest{Username: username}
 
 	reqBody, err := json.Marshal(req)
@@ -75,16 +75,16 @@ func doNew(c *client.Client, u string, username string) error {
 }
 
 // Delete removes a user from an app.
-func Delete(c *client.Client, appID string, username string) error {
+func Delete(c *deis.Client, appID string, username string) error {
 	return doDelete(c, fmt.Sprintf("/v2/apps/%s/perms/%s", appID, username))
 }
 
 // DeleteAdmin removes administrative privileges from a user.
-func DeleteAdmin(c *client.Client, username string) error {
+func DeleteAdmin(c *deis.Client, username string) error {
 	return doDelete(c, fmt.Sprintf("/v2/admin/perms/%s", username))
 }
 
-func doDelete(c *client.Client, u string) error {
+func doDelete(c *deis.Client, u string) error {
 	_, err := c.BasicRequest("DELETE", u, nil)
 	return err
 }

--- a/perms/perms_test.go
+++ b/perms/perms_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 )
 
 const adminFixture string = `
@@ -42,7 +42,7 @@ const appCreateExpected = `{"username":"foo"}`
 type fakeHTTPServer struct{}
 
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	res.Header().Add("DEIS_API_VERSION", client.APIVersion)
+	res.Header().Add("DEIS_API_VERSION", deis.APIVersion)
 
 	if req.URL.Path == "/v2/admin/perms/" && req.Method == "GET" {
 		res.Write([]byte(adminFixture))
@@ -125,12 +125,12 @@ func TestList(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := List(client, "example-go")
+	actual, err := List(deis, "example-go")
 
 	if err != nil {
 		t.Fatal(err)
@@ -153,12 +153,12 @@ func TestListAdmins(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, _, err := ListAdmins(client, 100)
+	actual, _, err := ListAdmins(deis, 100)
 
 	if err != nil {
 		t.Fatal(err)
@@ -176,12 +176,12 @@ func TestNew(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = New(client, "example-go", "foo"); err != nil {
+	if err = New(deis, "example-go", "foo"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -193,12 +193,12 @@ func TestNewAdmin(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = NewAdmin(client, "test"); err != nil {
+	if err = NewAdmin(deis, "test"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -210,12 +210,12 @@ func TestDelete(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = Delete(client, "example-go", "foo"); err != nil {
+	if err = Delete(deis, "example-go", "foo"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -227,12 +227,12 @@ func TestDeleteAdmin(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = DeleteAdmin(client, "test"); err != nil {
+	if err = DeleteAdmin(deis, "test"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/ps/ps.go
+++ b/ps/ps.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
 // List an app's processes.
-func List(c *client.Client, appID string, results int) ([]api.Pods, int, error) {
+func List(c *deis.Client, appID string, results int) ([]api.Pods, int, error) {
 	u := fmt.Sprintf("/v2/apps/%s/pods/", appID)
 	body, count, err := c.LimitedRequest(u, results)
 	if err != nil {
@@ -25,7 +25,7 @@ func List(c *client.Client, appID string, results int) ([]api.Pods, int, error) 
 }
 
 // Scale an app's processes.
-func Scale(c *client.Client, appID string, targets map[string]int) error {
+func Scale(c *deis.Client, appID string, targets map[string]int) error {
 	u := fmt.Sprintf("/v2/apps/%s/scale/", appID)
 
 	body, err := json.Marshal(targets)
@@ -39,7 +39,7 @@ func Scale(c *client.Client, appID string, targets map[string]int) error {
 }
 
 // Restart an app's processes.
-func Restart(c *client.Client, appID string, procType string, name string) ([]api.Pods, error) {
+func Restart(c *deis.Client, appID string, procType string, name string) ([]api.Pods, error) {
 	u := fmt.Sprintf("/v2/apps/%s/pods/", appID)
 
 	if procType == "" {

--- a/ps/ps_test.go
+++ b/ps/ps_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 	"github.com/deis/pkg/time"
 )
@@ -67,7 +67,7 @@ const scaleExpected string = `{"web":2}`
 type fakeHTTPServer struct{}
 
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	res.Header().Add("DEIS_API_VERSION", client.APIVersion)
+	res.Header().Add("DEIS_API_VERSION", deis.APIVersion)
 
 	if req.URL.Path == "/v2/apps/example-go/pods/" && req.Method == "GET" {
 		res.Write([]byte(processesFixture))
@@ -139,12 +139,12 @@ func TestProcessesList(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, _, err := List(client, "example-go", 100)
+	actual, _, err := List(deis, "example-go", 100)
 
 	if err != nil {
 		t.Fatal(err)
@@ -225,13 +225,13 @@ func TestAppsRestart(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, test := range tests {
-		actual, err := Restart(client, "example-go", test.Type, test.Name)
+		actual, err := Restart(deis, "example-go", test.Type, test.Name)
 
 		if err != nil {
 			t.Error(err)
@@ -250,12 +250,12 @@ func TestScale(t *testing.T) {
 	server := httptest.NewServer(&handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = Scale(client, "example-go", map[string]int{"web": 2}); err != nil {
+	if err = Scale(deis, "example-go", map[string]int{"web": 2}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/releases/releases.go
+++ b/releases/releases.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
 // List lists an app's releases.
-func List(c *client.Client, appID string, results int) ([]api.Release, int, error) {
+func List(c *deis.Client, appID string, results int) ([]api.Release, int, error) {
 	u := fmt.Sprintf("/v2/apps/%s/releases/", appID)
 
 	body, count, err := c.LimitedRequest(u, results)
@@ -27,7 +27,7 @@ func List(c *client.Client, appID string, results int) ([]api.Release, int, erro
 }
 
 // Get a release of an app.
-func Get(c *client.Client, appID string, version int) (api.Release, error) {
+func Get(c *deis.Client, appID string, version int) (api.Release, error) {
 	u := fmt.Sprintf("/v2/apps/%s/releases/v%d/", appID, version)
 
 	body, err := c.BasicRequest("GET", u, nil)
@@ -45,7 +45,7 @@ func Get(c *client.Client, appID string, version int) (api.Release, error) {
 }
 
 // Rollback rolls back an app to a previous release.
-func Rollback(c *client.Client, appID string, version int) (int, error) {
+func Rollback(c *deis.Client, appID string, version int) (int, error) {
 	u := fmt.Sprintf("/v2/apps/%s/releases/rollback/", appID)
 
 	req := api.ReleaseRollback{Version: version}

--- a/releases/releases_test.go
+++ b/releases/releases_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
@@ -59,7 +59,7 @@ const rollbackerExpected string = ``
 type fakeHTTPServer struct{}
 
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	res.Header().Add("DEIS_API_VERSION", client.APIVersion)
+	res.Header().Add("DEIS_API_VERSION", deis.APIVersion)
 
 	if req.URL.Path == "/v2/apps/example-go/releases/" && req.Method == "GET" {
 		res.Write([]byte(releasesFixture))
@@ -139,12 +139,12 @@ func TestReleasesList(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, _, err := List(client, "example-go", 100)
+	actual, _, err := List(deis, "example-go", 100)
 
 	if err != nil {
 		t.Fatal(err)
@@ -174,12 +174,12 @@ func TestReleasesGet(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := Get(client, "example-go", 1)
+	actual, err := Get(deis, "example-go", 1)
 
 	if err != nil {
 		t.Fatal(err)
@@ -199,12 +199,12 @@ func TestRollback(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := Rollback(client, "example-go", 2)
+	actual, err := Rollback(deis, "example-go", 2)
 
 	if err != nil {
 		t.Fatal(err)
@@ -224,12 +224,12 @@ func TestRollbacker(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := Rollback(client, "rollbacker", -1)
+	actual, err := Rollback(deis, "rollbacker", -1)
 
 	if err != nil {
 		t.Fatal(err)

--- a/users/users.go
+++ b/users/users.go
@@ -3,12 +3,12 @@ package users
 import (
 	"encoding/json"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
 // List users registered with the controller.
-func List(c *client.Client, results int) ([]api.User, int, error) {
+func List(c *deis.Client, results int) ([]api.User, int, error) {
 	body, count, err := c.LimitedRequest("/v2/users/", results)
 
 	if err != nil {

--- a/users/users_test.go
+++ b/users/users_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	client "github.com/deis/controller-sdk-go"
+	deis "github.com/deis/controller-sdk-go"
 	"github.com/deis/controller-sdk-go/api"
 )
 
@@ -37,7 +37,7 @@ const usersFixture string = `
 type fakeHTTPServer struct{}
 
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	res.Header().Add("DEIS_API_VERSION", client.APIVersion)
+	res.Header().Add("DEIS_API_VERSION", deis.APIVersion)
 
 	if req.URL.Path == "/v2/users/" && req.Method == "GET" {
 		res.Write([]byte(usersFixture))
@@ -71,12 +71,12 @@ func TestUsersList(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client, err := client.New(false, server.URL, "abc", "")
+	deis, err := deis.New(false, server.URL, "abc", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, _, err := List(client, 100)
+	actual, _, err := List(deis, 100)
 
 	if err != nil {
 		t.Fatal(err)

--- a/utils.go
+++ b/utils.go
@@ -1,4 +1,4 @@
-package client
+package deis
 
 func checkAPICompatibility(serverAPIVersion string) error {
 	if serverAPIVersion != APIVersion {


### PR DESCRIPTION
I think this just makes a little bit more sense to the godoc and the other people using the code. So you have a `deis.Client` instead of a `client.Client` and so on.

The `client` name came from when it was a subpackage of the cli.