### PR TITLE
fix(errors): ensure unknown errors look nice

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -2,6 +2,7 @@ package deis
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -257,12 +258,21 @@ func TestErrors(t *testing.T) {
 			},
 			expected: ErrServerError,
 		},
+		// ensure unknown errors at least look pretty
+		errorTest{
+			res: &http.Response{
+				StatusCode: 400,
+				Body:       readCloser(`{"detail":"unknown error"}`),
+			},
+			expected: errors.New(`Unknown Error (400): {"detail":"unknown error"}`),
+		},
 	}
 
 	for _, check := range tests {
 		actual := checkForErrors(check.res)
 
-		if actual != check.expected {
+		// specifically check error output rather than value comparison
+		if fmt.Sprintf("%v", actual) != fmt.Sprintf("%v", check.expected) {
 			t.Errorf(failureMessage, check.expected, actual)
 		}
 	}


### PR DESCRIPTION
One of the complaints has been that the SDK now shows ugly unknown errors like this:

> Creating build... Error: Unknown Error (400): map[detail:Post http://localhost:5555/v2/test-61453435/blobs/uploads/: net/http: transport closed before response was received]

With this change, the error will dump the raw JSON output instead.

> Creating build... Error: Unknown Error (400): {"detail": "Post http://localhost:5555/v2/test-61453435/blobs/uploads/: net/http: transport closed before response was received"}