### PR TITLE
chore(deis.go): bump api version to 2.2

### DIFF
--- a/deis.go
+++ b/deis.go
@@ -92,7 +92,7 @@ type Client struct {
 // controller is unsafe.
 //
 // If the SDK detects an API version mismatch, it will return ErrAPIMismatch.
-const APIVersion = "2.1"
+const APIVersion = "2.2"
 
 var (
 	// ErrAPIMismatch occurs when the sdk is using a different api version than the deis.


### PR DESCRIPTION
See deis/controller#929