### PR TITLE
fix(api): make Routable a *bool

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -45,7 +45,12 @@ type Config struct {
 	// It changes every time the configuration is changed and cannot be updated.
 	UUID string `json:"uuid,omitempty"`
 	// Routable determines if the application should be exposed by the router.
-	Routable bool `json:"routable,omitempty"`
+	Routable *bool `json:"routable,omitempty"`
+}
+
+func NewRoutable() *bool {
+	b := true
+	return &b
 }
 
 // ConfigHookRequest defines the request for configuration from the config hook.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -146,7 +146,7 @@ func TestConfigSet(t *testing.T) {
 		Registry: map[string]interface{}{
 			"username": "bob",
 		},
-		Routable: true,
+		Routable: api.NewRoutable(),
 		Created:  "2014-01-01T00:00:00UTC",
 		Updated:  "2014-01-01T00:00:00UTC",
 		UUID:     "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
@@ -169,7 +169,7 @@ func TestConfigSet(t *testing.T) {
 		Registry: map[string]interface{}{
 			"username": "bob",
 		},
-		Routable: true,
+		Routable: api.NewRoutable(),
 	}
 
 	actual, err := Set(deis, "example-go", configVars)
@@ -203,7 +203,7 @@ func TestConfigUnset(t *testing.T) {
 		CPU:      map[string]interface{}{},
 		Tags:     map[string]interface{}{},
 		Registry: map[string]interface{}{},
-		Routable: true,
+		Routable: api.NewRoutable(),
 		Created:  "2014-01-01T00:00:00UTC",
 		Updated:  "2014-01-01T00:00:00UTC",
 		UUID:     "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
@@ -226,7 +226,7 @@ func TestConfigUnset(t *testing.T) {
 		Registry: map[string]interface{}{
 			"username": nil,
 		},
-		Routable: true,
+		Routable: api.NewRoutable(),
 	}
 
 	actual, err := Set(deis, "unset-test", configVars)
@@ -271,7 +271,7 @@ func TestConfigList(t *testing.T) {
 		Registry: map[string]interface{}{
 			"username": "bob",
 		},
-		Routable: true,
+		Routable: api.NewRoutable(),
 		Created:  "2014-01-01T00:00:00UTC",
 		Updated:  "2014-01-01T00:00:00UTC",
 		UUID:     "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",


### PR DESCRIPTION
fixes the issue where the client would send an empty request on `deis routing:disable`.

see https://github.com/golang/go/issues/13284