### PR TITLE
fix(http.go): don't double the slash in /healthz URL

### DIFF
--- a/http.go
+++ b/http.go
@@ -139,7 +139,12 @@ your deis version is correct.`
 // Healthcheck can be called to see if the controller is healthy
 func (c *Client) Healthcheck() error {
 	// Make a request to /healthz and expect an ok HTTP response
-	req, err := http.NewRequest("GET", c.ControllerURL.String()+"/healthz", bytes.NewBuffer(nil))
+	controllerURL := c.ControllerURL.String()
+	// Don't double the last slash in the URL path
+	if !strings.HasSuffix(controllerURL, "/") {
+		controllerURL = controllerURL + "/"
+	}
+	req, err := http.NewRequest("GET", controllerURL+"healthz", bytes.NewBuffer(nil))
 	addUserAgent(&req.Header, c.UserAgent)
 
 	if err != nil {

--- a/http_test.go
+++ b/http_test.go
@@ -236,7 +236,19 @@ func TestHealthcheck(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	deis, err := New(false, server.URL, "")
+	// Test with a trailing slash
+	deis, err := New(false, server.URL+"/", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deis.UserAgent = "test"
+
+	if err = deis.Healthcheck(); err != nil {
+		t.Error(err)
+	}
+
+	// Test without a trailing slash
+	deis, err = New(false, server.URL, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
While testing some changes to controller, I noticed that builder's healthchecks were hitting a `//healthz` endpoint (with two slashes). Something in Django's WSGI normalizes this, but I was testing an ASGI server that didn't, so those malformed URL requests ended with 404s.

I modified the test to add a final slash to the base URL, then changed the code to avoid adding a redundant slash when forming the healthcheck endpoint.