### PR TITLE
ref(Dockerfile,Jenkinsfile): remove deprecated glide flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY glide.lock /go/src/github.com/deis/controller-sdk-go/
 
 WORKDIR /go/src/github.com/deis/controller-sdk-go
 
-RUN glide install --strip-vcs --strip-vendor
+RUN glide install --strip-vendor
 
 COPY ./_scripts /usr/local/bin
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ node('linux') {
 
 	def build_script = "sh -c 'perl -i -0pe \"s/${pattern}/${replacement}/\" glide.yaml "
 	build_script += "&& rm -rf glide.lock vendor/github.com/deis/controller-sdk-go "
-	build_script += "&& glide install --update-vendored "
+	build_script += "&& glide install "
 	build_script += "&& make build-revision'"
 	sh "docker pull ${wcli_image}"
 	sh "docker run ${flags} -e GIT_TAG=csdk -e REVISION=${git_commit.take(7)} ${dist_dir} --rm ${wcli_image} ${build_script}"


### PR DESCRIPTION
This behavior is the default in current versions of glide. Removing them avoids deprecation warnings.

Sorry, this should have been part of #104.