### PR TITLE
feat(label-cmd): add Label model

### DIFF
--- a/api/appsettings.go
+++ b/api/appsettings.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"fmt"
 	"text/template"
 )
 
@@ -24,6 +25,7 @@ type AppSettings struct {
 	Routable  *bool                 `json:"routable,omitempty"`
 	Whitelist []string              `json:"whitelist,omitempty"`
 	Autoscale map[string]*Autoscale `json:"autoscale,omitempty"`
+	Label     Labels                `json:"label,omitempty"`
 }
 
 // NewRoutable returns a default value for the AppSettings.Routable field.
@@ -60,4 +62,18 @@ type Autoscale struct {
 	Min        int `json:"min"`
 	Max        int `json:"max"`
 	CPUPercent int `json:"cpu_percent"`
+}
+
+// Labels can contain any user-defined key value
+type Labels map[string]interface{}
+
+func (l Labels) String() string {
+	var buffer bytes.Buffer
+	for k, v := range l {
+		if buffer.Len() > 0 {
+			buffer.WriteString("\n")
+		}
+		buffer.WriteString(fmt.Sprintf("%-16s %s", k+":", v))
+	}
+	return buffer.String()
 }

--- a/api/appsettings_test.go
+++ b/api/appsettings_test.go
@@ -30,3 +30,17 @@ CPU: 40%`)
 		t.Errorf("Expected:\n\n%s\n\nGot:\n\n%s", expected2, a2.String())
 	}
 }
+
+func TestLabelsString(t *testing.T) {
+	data := Labels{
+		"git_repo": "https://github.com/deis/controller-sdk-go",
+		"team":     "deis",
+	}
+
+	expected := strings.TrimSpace(`git_repo:        https://github.com/deis/controller-sdk-go
+team:            deis`)
+
+	if strings.TrimSpace(data.String()) != expected {
+		t.Errorf("Expected:\n\n%s\n\nGot:\n\n%s", expected, data.String())
+	}
+}

--- a/appsettings/appsettings_test.go
+++ b/appsettings/appsettings_test.go
@@ -20,6 +20,7 @@ const appSettingsFixture string = `
     "routable": true,
     "whitelist": ["1.2.3.4", "0.0.0.0/0"],
     "autoscale": {"cmd": {"min": 3, "max": 8, "cpu_percent": 40}},
+    "label": {"git_repo": "https://github.com/deis/controller-sdk-go", "team" : "deis"},
     "created": "2014-01-01T00:00:00UTC",
     "updated": "2014-01-01T00:00:00UTC",
     "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
@@ -34,14 +35,15 @@ const appSettingsUnsetFixture string = `
     "routable": true,
     "whitelist": ["1.2.3.4", "0.0.0.0/0"],
     "autoscale": {"cmd": {"min": 3, "max": 8, "cpu_percent": 40}},
+    "label": {"git_repo": "https://github.com/deis/controller-sdk-go", "team" : "deis"},
     "created": "2014-01-01T00:00:00UTC",
     "updated": "2014-01-01T00:00:00UTC",
     "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
 }
 `
 
-const appSettingsSetExpected string = `{"maintenance":true,"routable":true,"whitelist":["1.2.3.4","0.0.0.0/0"],"autoscale":{"cmd":{"min":3,"max":8,"cpu_percent":40}}}`
-const appSettingsUnsetExpected string = `{"maintenance":true,"routable":true,"whitelist":["1.2.3.4","0.0.0.0/0"],"autoscale":{"cmd":{"min":3,"max":8,"cpu_percent":40}}}`
+const appSettingsSetExpected string = `{"maintenance":true,"routable":true,"whitelist":["1.2.3.4","0.0.0.0/0"],"autoscale":{"cmd":{"min":3,"max":8,"cpu_percent":40}},"label":{"git_repo":"https://github.com/deis/controller-sdk-go","team":"deis"}}`
+const appSettingsUnsetExpected string = `{"maintenance":true,"routable":true,"whitelist":["1.2.3.4","0.0.0.0/0"],"autoscale":{"cmd":{"min":3,"max":8,"cpu_percent":40}},"label":{"git_repo":"https://github.com/deis/controller-sdk-go","team":"deis"}}`
 
 var trueVar = true
 
@@ -138,6 +140,10 @@ func TestAppSettingsSet(t *testing.T) {
 				CPUPercent: 40,
 			},
 		},
+		Label: map[string]interface{}{
+			"git_repo": "https://github.com/deis/controller-sdk-go",
+			"team":     "deis",
+		},
 		Created: "2014-01-01T00:00:00UTC",
 		Updated: "2014-01-01T00:00:00UTC",
 		UUID:    "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
@@ -153,6 +159,10 @@ func TestAppSettingsSet(t *testing.T) {
 				Max:        8,
 				CPUPercent: 40,
 			},
+		},
+		Label: map[string]interface{}{
+			"git_repo": "https://github.com/deis/controller-sdk-go",
+			"team":     "deis",
 		},
 	}
 
@@ -192,6 +202,10 @@ func TestAppSettingsUnset(t *testing.T) {
 				CPUPercent: 40,
 			},
 		},
+		Label: map[string]interface{}{
+			"git_repo": "https://github.com/deis/controller-sdk-go",
+			"team":     "deis",
+		},
 		Created: "2014-01-01T00:00:00UTC",
 		Updated: "2014-01-01T00:00:00UTC",
 		UUID:    "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
@@ -207,6 +221,10 @@ func TestAppSettingsUnset(t *testing.T) {
 				Max:        8,
 				CPUPercent: 40,
 			},
+		},
+		Label: map[string]interface{}{
+			"git_repo": "https://github.com/deis/controller-sdk-go",
+			"team":     "deis",
 		},
 	}
 
@@ -245,6 +263,10 @@ func TestAppSettingsList(t *testing.T) {
 				Max:        8,
 				CPUPercent: 40,
 			},
+		},
+		Label: map[string]interface{}{
+			"git_repo": "https://github.com/deis/controller-sdk-go",
+			"team":     "deis",
 		},
 		Created: "2014-01-01T00:00:00UTC",
 		Updated: "2014-01-01T00:00:00UTC",


### PR DESCRIPTION
Add Label model for workflow-cli new command Label.
Labels are general key value string to each app just for administration purpose.

See https://github.com/deis/workflow/issues/597