### PR TITLE
fix(healthcheck): Use correct keys for the http header of healthchecks

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -93,12 +93,12 @@ TCP Socket Probe: {{or .TCPSocket "N/A"}}`)
 // KVPair is a key/value pair used to parse values from
 // strings into a formal structure.
 type KVPair struct {
-	Key   string `json:"key"`
+	Name  string `json:"name"`
 	Value string `json:"value"`
 }
 
 func (k KVPair) String() string {
-	return k.Key + "=" + k.Value
+	return k.Name + "=" + k.Value
 }
 
 // ExecProbe executes a command within a Pod.

--- a/api/config_test.go
+++ b/api/config_test.go
@@ -24,7 +24,7 @@ TCP Socket Probe: N/A`)
 	h.HTTPGet = &HTTPGetProbe{
 		Path:        "/",
 		Port:        80,
-		HTTPHeaders: []*KVPair{{Key: "X-DEIS-IS", Value: "AWESOME"}},
+		HTTPHeaders: []*KVPair{{Name: "X-DEIS-IS", Value: "AWESOME"}},
 	}
 
 	expected = strings.TrimSpace(`Initial Delay (seconds): 0


### PR DESCRIPTION
http://kubernetes.io/docs/api-reference/v1/definitions/#_v1_httpheader