### PR TITLE
chore(Dockerfile): update go-dev to v0.21.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/go-dev:0.20.0
+FROM quay.io/deis/go-dev:v0.21.0
 # This Dockerfile is used to bundle the source and all dependencies into an image for testing.
 
 ADD https://codecov.io/bash /usr/local/bin/codecov

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Register a new user with the controller.
-// If controller registration is set to administratiors only, a valid administrative
+// If controller registration is set to administrators only, a valid administrative
 // user token is required in the client.
 func Register(c *deis.Client, username, password, email string) error {
 	user := api.AuthRegisterRequest{Username: username, Password: password, Email: email}

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -51,7 +51,7 @@ func GetAppConfig(c *deis.Client, username, app string) (api.Config, error) {
 }
 
 // CreateBuild creates a new release of an application. It returns the version of the new release.
-// gitSha should be the first 8 charecters of the git commit sha. Image is either the docker image
+// gitSha should be the first 8 characters of the git commit sha. Image is either the docker image
 // location for the dockerfile app the absolute url to the tar file for a buldpack app.
 func CreateBuild(c *deis.Client, username, app, image, gitSha string, procfile api.ProcessType,
 	usingDockerifle bool) (int, error) {

--- a/http.go
+++ b/http.go
@@ -109,7 +109,7 @@ func (c *Client) CheckConnection() error {
 Make sure that the Controller URI is correct, the server is running and
 your deis version is correct.`
 
-	// Make a request to /v2/ and expect a 401 respone
+	// Make a request to /v2/ and expect a 401 response
 	req, err := http.NewRequest("GET", c.ControllerURL.String()+"/v2/", bytes.NewBuffer(nil))
 	addUserAgent(&req.Header, c.UserAgent)
 

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -31,6 +31,9 @@ func List(c *deis.Client, results int) (api.Keys, int, error) {
 func New(c *deis.Client, id string, pubKey string) (api.Key, error) {
 	req := api.KeyCreateRequest{ID: id, Public: pubKey}
 	body, err := json.Marshal(req)
+	if err != nil {
+		return api.Key{}, err
+	}
 
 	res, reqErr := c.Request("POST", "/v2/keys/", body)
 	if reqErr != nil && !deis.IsErrAPIMismatch(reqErr) {


### PR DESCRIPTION
Includes an OS X cert settings fix and keeps `go-dev` synced with workflow-cli. See also deis/workflow-cli#281.

See https://github.com/golang/go/issues?q=milestone%3AGo1.7.4