### PR TITLE
fix(errors): display the error on a 404

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -35,8 +35,6 @@ const (
 )
 
 var (
-	// ErrNotFound is returned when the server returns a 404.
-	ErrNotFound = errors.New("Not Found")
 	// ErrServerError is returned when the server returns a 500.
 	ErrServerError = errors.New("Internal Server Error")
 	// ErrMethodNotAllowed is thrown when using a unsupposrted method.
@@ -93,8 +91,17 @@ type ErrUnprocessable struct {
 	errorMsg string
 }
 
+// ErrNotFound is returned when the controller throws a 404.
+type ErrNotFound struct {
+	errorMsg string
+}
+
 func (e ErrUnprocessable) Error() string {
 	return fmt.Sprintf("Unable to process your request: %s", e.errorMsg)
+}
+
+func (e ErrNotFound) Error() string {
+	return e.errorMsg
 }
 
 // checkForErrors tries to match up an API error with an predefined error in the SDK.
@@ -197,7 +204,10 @@ func checkForErrors(res *http.Response) error {
 	case 403:
 		return ErrForbidden
 	case 404:
-		return ErrNotFound
+		if string(out) != "" {
+			return ErrNotFound{string(out)}
+		}
+		return ErrNotFound{"Not Found"}
 	case 405:
 		return ErrMethodNotAllowed
 	case 409:

--- a/errors_test.go
+++ b/errors_test.go
@@ -241,7 +241,14 @@ func TestErrors(t *testing.T) {
 				StatusCode: 404,
 				Body:       readCloser(""),
 			},
-			expected: ErrNotFound,
+			expected: ErrNotFound{"Not Found"},
+		},
+		{
+			res: &http.Response{
+				StatusCode: 404,
+				Body:       readCloser("App not found"),
+			},
+			expected: ErrNotFound{"App not found"},
 		},
 		{
 			res: &http.Response{


### PR DESCRIPTION
Some 404 error messages like when an app has not been found returns a specific message for the
user. Returning a generic "Not Found" message is not helpful.